### PR TITLE
Typo: use default export over named.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following script:
 import { readFile } from 'node:fs/promises'
 
 import { compile } from '@mdx-js/mdx'
-import { rehypeMdxCodeProps } from 'rehype-mdx-code-props'
+import rehypeMdxCodeProps from 'rehype-mdx-code-props'
 
 const { value } = await compile(await readFile('example.mdx'), {
   jsx: true,


### PR DESCRIPTION
The [source code](https://github.com/remcohaszing/rehype-mdx-code-props/blob/626efbf8f0f1f182923cc5d356bb503230b62d0b/index.ts#L111) uses a default export, as is convention. So I got an error when using the named export.