### PR TITLE
Generate mdxJsxAttribute nodes instead of ESTree

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,3 +1,5 @@
 root: true
 extends:
   - remcohaszing
+rules:
+  no-param-reassign: off

--- a/fixtures/boolean/expected-code.jsx
+++ b/fixtures/boolean/expected-code.jsx
@@ -8,11 +8,9 @@ function _createMdxContent(props) {
   }
   return (
     <_components.pre>
-      {
-        <_components.code className="language-js" copy>
-          {"console.log('Hello World!')\n"}
-        </_components.code>
-      }
+      <_components.code className="language-js" copy>
+        {"console.log('Hello World!')\n"}
+      </_components.code>
     </_components.pre>
   )
 }

--- a/fixtures/boolean/expected-pre.jsx
+++ b/fixtures/boolean/expected-pre.jsx
@@ -7,15 +7,9 @@ function _createMdxContent(props) {
     ...props.components
   }
   return (
-    <>
-      {
-        <_components.pre copy>
-          <_components.code className="language-js">
-            {"console.log('Hello World!')\n"}
-          </_components.code>
-        </_components.pre>
-      }
-    </>
+    <_components.pre copy>
+      <_components.code className="language-js">{"console.log('Hello World!')\n"}</_components.code>
+    </_components.pre>
   )
 }
 export default function MDXContent(props = {}) {

--- a/fixtures/jsx-expression/expected-code.jsx
+++ b/fixtures/jsx-expression/expected-code.jsx
@@ -8,11 +8,9 @@ function _createMdxContent(props) {
   }
   return (
     <_components.pre>
-      {
-        <_components.code className="language-js" onClick={props.onClick}>
-          {"console.log('Hello World!')\n"}
-        </_components.code>
-      }
+      <_components.code className="language-js" onClick={props.onClick}>
+        {"console.log('Hello World!')\n"}
+      </_components.code>
     </_components.pre>
   )
 }

--- a/fixtures/jsx-expression/expected-pre.jsx
+++ b/fixtures/jsx-expression/expected-pre.jsx
@@ -7,15 +7,9 @@ function _createMdxContent(props) {
     ...props.components
   }
   return (
-    <>
-      {
-        <_components.pre onClick={props.onClick}>
-          <_components.code className="language-js">
-            {"console.log('Hello World!')\n"}
-          </_components.code>
-        </_components.pre>
-      }
-    </>
+    <_components.pre onClick={props.onClick}>
+      <_components.code className="language-js">{"console.log('Hello World!')\n"}</_components.code>
+    </_components.pre>
   )
 }
 export default function MDXContent(props = {}) {

--- a/fixtures/jsx-spread/expected-code.jsx
+++ b/fixtures/jsx-spread/expected-code.jsx
@@ -8,11 +8,9 @@ function _createMdxContent(props) {
   }
   return (
     <_components.pre>
-      {
-        <_components.code className="language-js" {...props}>
-          {"console.log('Hello World!')\n"}
-        </_components.code>
-      }
+      <_components.code className="language-js" {...props}>
+        {"console.log('Hello World!')\n"}
+      </_components.code>
     </_components.pre>
   )
 }

--- a/fixtures/jsx-spread/expected-pre.jsx
+++ b/fixtures/jsx-spread/expected-pre.jsx
@@ -7,15 +7,9 @@ function _createMdxContent(props) {
     ...props.components
   }
   return (
-    <>
-      {
-        <_components.pre {...props}>
-          <_components.code className="language-js">
-            {"console.log('Hello World!')\n"}
-          </_components.code>
-        </_components.pre>
-      }
-    </>
+    <_components.pre {...props}>
+      <_components.code className="language-js">{"console.log('Hello World!')\n"}</_components.code>
+    </_components.pre>
   )
 }
 export default function MDXContent(props = {}) {

--- a/fixtures/string/expected-code.jsx
+++ b/fixtures/string/expected-code.jsx
@@ -8,11 +8,9 @@ function _createMdxContent(props) {
   }
   return (
     <_components.pre>
-      {
-        <_components.code className="language-js" filename="script.js">
-          {"console.log('Hello World!')\n"}
-        </_components.code>
-      }
+      <_components.code className="language-js" filename="script.js">
+        {"console.log('Hello World!')\n"}
+      </_components.code>
     </_components.pre>
   )
 }

--- a/fixtures/string/expected-pre.jsx
+++ b/fixtures/string/expected-pre.jsx
@@ -7,15 +7,9 @@ function _createMdxContent(props) {
     ...props.components
   }
   return (
-    <>
-      {
-        <_components.pre filename="script.js">
-          <_components.code className="language-js">
-            {"console.log('Hello World!')\n"}
-          </_components.code>
-        </_components.pre>
-      }
-    </>
+    <_components.pre filename="script.js">
+      <_components.code className="language-js">{"console.log('Hello World!')\n"}</_components.code>
+    </_components.pre>
   )
 }
 export default function MDXContent(props = {}) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
-        "hast-util-to-estree": "^3.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-mdx": "^3.0.0",
         "micromark-extension-mdxjs": "^3.0.0",
@@ -2975,6 +2974,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
       "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0"
       },
@@ -3557,6 +3557,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.0.tgz",
       "integrity": "sha512-lfX5g6hqVh9kjS/B9E2gSkvHH4SZNiQFiqWS0x9fENzEl+8W12RqdRxX6d/Cwxi30tPQs3bIO+aolQJNp1bIyw==",
+      "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
         "@types/estree-jsx": "^1.0.0",
@@ -3626,6 +3627,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -3729,7 +3731,8 @@
     "node_modules/inline-style-parser": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
-      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
+      "dev": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -13714,6 +13717,7 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
       "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
+      "dev": true,
       "dependencies": {
         "inline-style-parser": "0.1.1"
       }
@@ -14562,6 +14566,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,13 @@
       "dependencies": {
         "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
+        "estree-util-value-to-estree": "^3.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-mdx": "^3.0.0",
         "micromark-extension-mdxjs": "^3.0.0",
         "property-information": "^6.0.0",
         "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
         "unified": "^11.0.0",
         "unist-util-visit-parents": "^6.0.0"
       },
@@ -3023,6 +3025,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-util-value-to-estree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.0.1.tgz",
+      "integrity": "sha512-b2tdzTurEIbwRh+mKrEcaWfu1wgb8J1hVsgREg7FFiecWwK/PhO8X0kyc+0bIcKNtD4sqxIdNoRy6/p/TvECEA==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "is-plain-obj": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
     "node_modules/estree-util-visit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
@@ -3581,6 +3598,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-estree/node_modules/inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
+      "dev": true
+    },
+    "node_modules/hast-util-to-estree/node_modules/style-to-object": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
+      "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
+      "dev": true,
+      "dependencies": {
+        "inline-style-parser": "0.1.1"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.0.tgz",
@@ -3606,21 +3638,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-jsx-runtime/node_modules/inline-style-parser": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.2.tgz",
-      "integrity": "sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ==",
-      "dev": true
-    },
-    "node_modules/hast-util-to-jsx-runtime/node_modules/style-to-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.5.tgz",
-      "integrity": "sha512-rDRwHtoDD3UMMrmZ6BzOW0naTjMsVZLIjsGleSKS/0Oz+cgCfAPRspaqJuE8rDzpKha/nEvnM0IF4seEAZUTKQ==",
-      "dev": true,
-      "dependencies": {
-        "inline-style-parser": "0.2.2"
       }
     },
     "node_modules/hast-util-whitespace": {
@@ -3729,10 +3746,9 @@
       }
     },
     "node_modules/inline-style-parser": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
-      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
-      "dev": true
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.2.tgz",
+      "integrity": "sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -13713,13 +13729,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/style-to-object": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
-      "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
-      "dev": true,
+    "node_modules/style-to-js": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.10.tgz",
+      "integrity": "sha512-VC7MBJa+y0RZhpnLKDPmVRLRswsASLmixkiZ5R8xZpNT9VyjeRzwnXd2pBzAWdgSGv/pCNNH01gPCCUsB9exYg==",
       "dependencies": {
-        "inline-style-parser": "0.1.1"
+        "style-to-object": "1.0.5"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.5.tgz",
+      "integrity": "sha512-rDRwHtoDD3UMMrmZ6BzOW0naTjMsVZLIjsGleSKS/0Oz+cgCfAPRspaqJuE8rDzpKha/nEvnM0IF4seEAZUTKQ==",
+      "dependencies": {
+        "inline-style-parser": "0.2.2"
       }
     },
     "node_modules/supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
-        "acorn": "^8.0.0",
-        "acorn-jsx": "^5.0.0",
+        "comma-separated-tokens": "^2.0.0",
         "hast-util-to-estree": "^3.0.0",
+        "property-information": "^6.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "space-separated-tokens": "^2.0.0",
         "unified": "^11.0.0",
         "unist-util-visit-parents": "^6.0.0"
       },
       "devDependencies": {
         "@mdx-js/mdx": "^3.0.0",
-        "@types/estree": "^1.0.0",
         "@types/node": "^20.0.0",
         "@types/react": "^18.0.0",
         "c8": "^9.0.0",
@@ -26,6 +28,7 @@
         "eslint-config-remcohaszing": "^10.0.0",
         "eslint-plugin-jsx-a11y": "^6.0.0",
         "eslint-plugin-react": "^7.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
         "prettier": "^3.0.0",
         "remark-cli": "11.0.0",
         "remark-preset-remcohaszing": "^2.0.0",
@@ -685,7 +688,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
       "integrity": "sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "*"
       }
@@ -2953,7 +2955,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
       "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
-      "dev": true,
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
         "@types/unist": "^3.0.0"
@@ -6602,7 +6603,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
       "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
-      "dev": true,
       "dependencies": {
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-mdx-expression": "^2.0.0",
@@ -6966,7 +6966,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
       "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -6975,7 +6974,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
       "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
@@ -6999,7 +6997,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^4.0.0"
       },
@@ -7012,7 +7009,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
       "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -7047,7 +7043,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
       "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -7063,7 +7058,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
       "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8468,7 +8462,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.0.tgz",
       "integrity": "sha512-sI0nwhUDz97xyzqJAbHQhp5TfaxEvZZZ2JDqUo+7NvyIYG6BZ5CPPqj2ogUoPJlmXHBnyZUzISg9+oUmU6tUjQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8494,7 +8487,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.0.tgz",
       "integrity": "sha512-uvhhss8OGuzR4/N17L1JwvmJIpPhAd8oByMawEKx6NVdBCbesjH4t+vjEp3ZXft9DwvlKSD07fCeI44/N0Vf2w==",
-      "dev": true,
       "dependencies": {
         "@types/acorn": "^4.0.0",
         "@types/estree": "^1.0.0",
@@ -8516,7 +8508,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
       "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
-      "dev": true,
       "dependencies": {
         "micromark-util-types": "^2.0.0"
       },
@@ -8529,7 +8520,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
       "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
-      "dev": true,
       "dependencies": {
         "acorn": "^8.0.0",
         "acorn-jsx": "^5.0.0",
@@ -8549,7 +8539,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
       "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
         "devlop": "^1.0.0",
@@ -8611,7 +8600,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.1.tgz",
       "integrity": "sha512-F0ccWIUHRLRrYp5TC9ZYXmZo+p2AM13ggbsW4T0b5CRKP8KHVRB8t4pwtBgTxtjRmwrK0Irwm7vs2JOZabHZfg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8829,7 +8817,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.2.tgz",
       "integrity": "sha512-Fk+xmBrOv9QZnEDguL9OI9/NQQp6Hz4FuQ4YmCb/5V7+9eAh1s6AYSvL20kHkD67YIg7EpE54TiSlcsf3vyZgA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -11575,7 +11562,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.0.1.tgz",
       "integrity": "sha512-3Pz3yPQ5Rht2pM5R+0J2MrGoBSrzf+tJG94N+t/ilfdh8YLyyKYtidAYwTveB20BoHAcwIopOUqhcmh2F7hGYA==",
-      "dev": true,
       "dependencies": {
         "mdast-util-mdx": "^3.0.0",
         "micromark-extension-mdxjs": "^3.0.0"
@@ -11589,7 +11575,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -11605,7 +11590,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
       "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -11614,7 +11598,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
       "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
@@ -11638,7 +11621,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^4.0.0"
       },
@@ -11651,7 +11633,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
       "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -11686,7 +11667,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
       "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -11702,7 +11682,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
       "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -15011,7 +14990,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
       "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,10 @@
         "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
         "hast-util-to-estree": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0",
         "property-information": "^6.0.0",
-        "remark-mdx": "^3.0.0",
-        "remark-parse": "^11.0.0",
         "space-separated-tokens": "^2.0.0",
         "unified": "^11.0.0",
         "unist-util-visit-parents": "^6.0.0"
@@ -2574,6 +2575,77 @@
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/eslint-plugin-markdown/node_modules/@types/unist": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/eslint-plugin-markdown/node_modules/mdast-util-from-markdown": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "micromark": "~2.11.0",
+        "parse-entities": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/eslint-plugin-markdown/node_modules/mdast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "dev": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/eslint-plugin-markdown/node_modules/micromark": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.0.0",
+        "parse-entities": "^2.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-markdown/node_modules/unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/eslint-plugin-n": {
       "version": "16.6.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.6.2.tgz",
@@ -4555,42 +4627,34 @@
       }
     },
     "node_modules/mdast-util-from-markdown": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
-      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
-      "dev": true,
-      "peer": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
+      "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
       "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-string": "^2.0.0",
-        "micromark": "~2.11.0",
-        "parse-entities": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdast-util-from-markdown/node_modules/@types/unist": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
-      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/mdast-util-from-markdown/node_modules/unist-util-stringify-position": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-      "dev": true,
-      "peer": true,
+    "node_modules/mdast-util-from-markdown/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
       "dependencies": {
-        "@types/unist": "^2.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
+        "@types/unist": "*"
       }
     },
     "node_modules/mdast-util-frontmatter": {
@@ -6640,110 +6704,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/mdast-util-mdx-expression/node_modules/mdast-util-from-markdown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
-      "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark": "^4.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdx-expression/node_modules/mdast-util-to-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "dependencies": {
-        "@types/mdast": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdx-expression/node_modules/micromark": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
-      "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/mdast-util-mdx-expression/node_modules/micromark-util-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
-      "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ]
-    },
-    "node_modules/mdast-util-mdx-expression/node_modules/micromark-util-sanitize-uri": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
-      "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
     "node_modules/mdast-util-mdx-jsx": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.1.2.tgz",
@@ -6834,110 +6794,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/mdast-util-mdx-jsx/node_modules/mdast-util-from-markdown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
-      "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark": "^4.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdx-jsx/node_modules/mdast-util-to-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "dependencies": {
-        "@types/mdast": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdx-jsx/node_modules/micromark": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
-      "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/mdast-util-mdx-jsx/node_modules/micromark-util-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
-      "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ]
-    },
-    "node_modules/mdast-util-mdx-jsx/node_modules/micromark-util-sanitize-uri": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
-      "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
     "node_modules/mdast-util-mdx-jsx/node_modules/parse-entities": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.1.tgz",
@@ -6962,118 +6818,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
       "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
     },
-    "node_modules/mdast-util-mdx/node_modules/@types/mdast": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
-      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/mdast-util-mdx/node_modules/mdast-util-from-markdown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
-      "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark": "^4.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdx/node_modules/mdast-util-to-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "dependencies": {
-        "@types/mdast": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdx/node_modules/micromark": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
-      "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/mdast-util-mdx/node_modules/micromark-util-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
-      "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ]
-    },
-    "node_modules/mdast-util-mdx/node_modules/micromark-util-sanitize-uri": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
-      "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
     "node_modules/mdast-util-mdxjs-esm": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
@@ -7097,110 +6841,6 @@
       "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
       "dependencies": {
         "@types/unist": "*"
-      }
-    },
-    "node_modules/mdast-util-mdxjs-esm/node_modules/mdast-util-from-markdown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
-      "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark": "^4.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdxjs-esm/node_modules/mdast-util-to-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "dependencies": {
-        "@types/mdast": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdxjs-esm/node_modules/micromark": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
-      "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/mdast-util-mdxjs-esm/node_modules/micromark-util-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
-      "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ]
-    },
-    "node_modules/mdast-util-mdxjs-esm/node_modules/micromark-util-sanitize-uri": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
-      "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
       }
     },
     "node_modules/mdast-util-phrasing": {
@@ -7318,18 +6958,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/mdast-util-to-markdown/node_modules/mdast-util-to-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "dependencies": {
-        "@types/mdast": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/mdast-util-to-nlcst": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-nlcst/-/mdast-util-to-nlcst-5.2.1.tgz",
@@ -7412,14 +7040,23 @@
       }
     },
     "node_modules/mdast-util-to-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
-      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
-      "dev": true,
-      "peer": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/mdast-util-toc": {
@@ -7513,10 +7150,9 @@
       }
     },
     "node_modules/micromark": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
-      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
+      "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -7527,10 +7163,24 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "peer": true,
       "dependencies": {
+        "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
-        "parse-entities": "^2.0.0"
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
       }
     },
     "node_modules/micromark-core-commonmark": {
@@ -9012,6 +8662,41 @@
           "url": "https://opencollective.com/unified"
         }
       ]
+    },
+    "node_modules/micromark/node_modules/micromark-util-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+      "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark/node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+      "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -11562,6 +11247,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.0.1.tgz",
       "integrity": "sha512-3Pz3yPQ5Rht2pM5R+0J2MrGoBSrzf+tJG94N+t/ilfdh8YLyyKYtidAYwTveB20BoHAcwIopOUqhcmh2F7hGYA==",
+      "dev": true,
       "dependencies": {
         "mdast-util-mdx": "^3.0.0",
         "micromark-extension-mdxjs": "^3.0.0"
@@ -11575,6 +11261,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dev": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -11590,112 +11277,9 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
       "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dev": true,
       "dependencies": {
         "@types/unist": "*"
-      }
-    },
-    "node_modules/remark-parse/node_modules/mdast-util-from-markdown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
-      "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark": "^4.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-parse/node_modules/mdast-util-to-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "dependencies": {
-        "@types/mdast": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-parse/node_modules/micromark": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
-      "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/remark-parse/node_modules/micromark-util-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
-      "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ]
-    },
-    "node_modules/remark-parse/node_modules/micromark-util-sanitize-uri": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
-      "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
       }
     },
     "node_modules/remark-preset-remcohaszing": {

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
   "dependencies": {
     "@types/hast": "^3.0.0",
     "comma-separated-tokens": "^2.0.0",
-    "hast-util-to-estree": "^3.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-mdx": "^3.0.0",
+    "micromark-extension-mdxjs": "^3.0.0",
     "property-information": "^6.0.0",
-    "remark-mdx": "^3.0.0",
-    "remark-parse": "^11.0.0",
     "space-separated-tokens": "^2.0.0",
     "unified": "^11.0.0",
     "unist-util-visit-parents": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -33,11 +33,13 @@
   "dependencies": {
     "@types/hast": "^3.0.0",
     "comma-separated-tokens": "^2.0.0",
+    "estree-util-value-to-estree": "^3.0.0",
     "mdast-util-from-markdown": "^2.0.0",
     "mdast-util-mdx": "^3.0.0",
     "micromark-extension-mdxjs": "^3.0.0",
     "property-information": "^6.0.0",
     "space-separated-tokens": "^2.0.0",
+    "style-to-js": "^1.0.0",
     "unified": "^11.0.0",
     "unist-util-visit-parents": "^6.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -32,15 +32,17 @@
   },
   "dependencies": {
     "@types/hast": "^3.0.0",
-    "acorn": "^8.0.0",
-    "acorn-jsx": "^5.0.0",
+    "comma-separated-tokens": "^2.0.0",
     "hast-util-to-estree": "^3.0.0",
+    "property-information": "^6.0.0",
+    "remark-mdx": "^3.0.0",
+    "remark-parse": "^11.0.0",
+    "space-separated-tokens": "^2.0.0",
     "unified": "^11.0.0",
     "unist-util-visit-parents": "^6.0.0"
   },
   "devDependencies": {
     "@mdx-js/mdx": "^3.0.0",
-    "@types/estree": "^1.0.0",
     "@types/node": "^20.0.0",
     "@types/react": "^18.0.0",
     "c8": "^9.0.0",
@@ -48,6 +50,7 @@
     "eslint-config-remcohaszing": "^10.0.0",
     "eslint-plugin-jsx-a11y": "^6.0.0",
     "eslint-plugin-react": "^7.0.0",
+    "mdast-util-mdx-jsx": "^3.0.0",
     "prettier": "^3.0.0",
     "remark-cli": "11.0.0",
     "remark-preset-remcohaszing": "^2.0.0",

--- a/src/rehype-mdx-code-props.ts
+++ b/src/rehype-mdx-code-props.ts
@@ -1,11 +1,12 @@
 import { stringify as commas } from 'comma-separated-tokens'
 import { type Root } from 'hast'
+import { fromMarkdown } from 'mdast-util-from-markdown'
+import { mdxFromMarkdown } from 'mdast-util-mdx'
 import { type MdxJsxFlowElementHast } from 'mdast-util-mdx-jsx'
+import { mdxjs } from 'micromark-extension-mdxjs'
 import { find, hastToReact, html } from 'property-information'
-import remarkMdx from 'remark-mdx'
-import remarkParse from 'remark-parse'
 import { stringify as spaces } from 'space-separated-tokens'
-import { type Plugin, unified } from 'unified'
+import { type Plugin } from 'unified'
 import { visitParents } from 'unist-util-visit-parents'
 
 /**
@@ -19,8 +20,6 @@ declare module 'hast' {
     meta?: string
   }
 }
-
-const parser = unified().use(remarkParse).use(remarkMdx)
 
 export interface RehypeMdxCodePropsOptions {
   /**
@@ -77,8 +76,10 @@ const rehypeMdxCodeProps: Plugin<[RehypeMdxCodePropsOptions?], Root> = ({
       }
 
       const line = child.position?.start.line || 1
-      const replacement = parser.parse(`${'\n'.repeat(line - 1)}<${child.tagName} ${meta} />`)
-        .children[0] as MdxJsxFlowElementHast
+      const replacement = fromMarkdown(`${'\n'.repeat(line - 1)}<${child.tagName} ${meta} />`, {
+        extensions: [mdxjs()],
+        mdastExtensions: [mdxFromMarkdown()]
+      }).children[0] as MdxJsxFlowElementHast
       replacement.children = child.children
       replacement.data = child.data
       replacement.position = child.position

--- a/src/rehype-mdx-code-props.ts
+++ b/src/rehype-mdx-code-props.ts
@@ -1,15 +1,11 @@
-import { Parser } from 'acorn'
-import jsx from 'acorn-jsx'
-import {
-  type ExpressionStatement,
-  type JSXAttribute,
-  type JSXElement,
-  type JSXSpreadAttribute,
-  type Program
-} from 'estree-jsx'
+import { stringify as commas } from 'comma-separated-tokens'
 import { type Root } from 'hast'
-import { toEstree } from 'hast-util-to-estree'
-import { type Plugin } from 'unified'
+import { type MdxJsxFlowElementHast } from 'mdast-util-mdx-jsx'
+import { find, hastToReact, html } from 'property-information'
+import remarkMdx from 'remark-mdx'
+import remarkParse from 'remark-parse'
+import { stringify as spaces } from 'space-separated-tokens'
+import { type Plugin, unified } from 'unified'
 import { visitParents } from 'unist-util-visit-parents'
 
 /**
@@ -24,38 +20,7 @@ declare module 'hast' {
   }
 }
 
-type JSXAttributes = (JSXAttribute | JSXSpreadAttribute)[]
-
-const parser = Parser.extend(jsx())
-
-/**
- * Get the JSX attributes for an estree program containing just a single JSX element.
- *
- * @param program
- *   The estree program
- * @returns
- *   The JSX attributes of the JSX element.
- */
-function getOpeningAttributes(program: Program): JSXAttributes {
-  const { expression } = program.body[0] as ExpressionStatement
-  const { openingElement } = expression as JSXElement
-  return openingElement.attributes
-}
-
-/**
- * Convert code meta to JSX elements.
- *
- * @param meta
- *   The meta to conert
- * @returns
- *   A list of MDX JSX attributes.
- */
-function parseMeta(meta: string): JSXAttributes {
-  const program = parser.parse(`<c ${meta} />`, {
-    ecmaVersion: 'latest'
-  }) as Program
-  return getOpeningAttributes(program)
-}
+const parser = unified().use(remarkParse).use(remarkMdx)
 
 export interface RehypeMdxCodePropsOptions {
   /**
@@ -111,14 +76,38 @@ const rehypeMdxCodeProps: Plugin<[RehypeMdxCodePropsOptions?], Root> = ({
         parent = ancestors.at(-2)!
       }
 
-      const estree = toEstree(child)
-      getOpeningAttributes(estree).push(...parseMeta(meta))
+      const line = child.position?.start.line || 1
+      const replacement = parser.parse(`${'\n'.repeat(line - 1)}<${child.tagName} ${meta} />`)
+        .children[0] as MdxJsxFlowElementHast
+      replacement.children = child.children
+      replacement.data = child.data
+      replacement.position = child.position
 
-      parent.children[parent.children.indexOf(child)] = {
-        type: 'mdxFlowExpression',
-        value: '',
-        data: { estree }
+      // Processing attributes is strongly based on
+      // https://github.com/syntax-tree/hast-util-to-estree/blob/3.1.0/lib/handlers/element.js
+      for (let [name, value] of Object.entries(child.properties)) {
+        const info = find(html, name)
+
+        if (value == null || value === false || Number.isNaN(value) || (!value && info.boolean)) {
+          continue
+        }
+
+        name = hastToReact[info.property] || info.property
+
+        if (Array.isArray(value)) {
+          value = info.commaSeparated ? commas(value) : spaces(value)
+        } else if (typeof value === 'number') {
+          value = String(value)
+        }
+
+        replacement.attributes.unshift({
+          type: 'mdxJsxAttribute',
+          name,
+          value: value === true ? null : value
+        })
       }
+
+      parent.children[parent.children.indexOf(child)] = replacement
     })
   }
 }

--- a/src/rehype-mdx-code-props.ts
+++ b/src/rehype-mdx-code-props.ts
@@ -75,8 +75,7 @@ const rehypeMdxCodeProps: Plugin<[RehypeMdxCodePropsOptions?], Root> = ({
         parent = ancestors.at(-2)!
       }
 
-      const line = child.position?.start.line || 1
-      const replacement = fromMarkdown(`${'\n'.repeat(line - 1)}<${child.tagName} ${meta} />`, {
+      const replacement = fromMarkdown(`<${child.tagName} ${meta} />`, {
         extensions: [mdxjs()],
         mdastExtensions: [mdxFromMarkdown()]
       }).children[0] as MdxJsxFlowElementHast

--- a/src/test.ts
+++ b/src/test.ts
@@ -8,6 +8,7 @@ import { type Root } from 'hast'
 import prettier from 'prettier'
 import rehypeMdxCodeProps from 'rehype-mdx-code-props'
 import { read } from 'to-vfile'
+import { visitParents } from 'unist-util-visit-parents'
 
 const fixturesDir = new URL('../fixtures/', import.meta.url)
 
@@ -194,6 +195,166 @@ test('code with pre parent and siblings', async () => {
       '    ...props.components\n' +
       '  };\n' +
       '  return <_components.pre><_components.code /><_components.code /></_components.pre>;\n' +
+      '}\n' +
+      'export default function MDXContent(props = {}) {\n' +
+      '  const {wrapper: MDXLayout} = props.components || ({});\n' +
+      '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);\n' +
+      '}\n'
+  )
+})
+
+test('boolean properties true', async () => {
+  const { value } = await compile('```js prop={prop}\n```\n', {
+    jsx: true,
+    rehypePlugins: [
+      () => (ast: Root) => {
+        visitParents(ast, { type: 'element', tagName: 'pre' }, (element) => {
+          element.properties.hidden = true
+        })
+      },
+      rehypeMdxCodeProps
+    ]
+  })
+
+  assert.equal(
+    value,
+    '/*@jsxRuntime automatic*/\n' +
+      '/*@jsxImportSource react*/\n' +
+      'function _createMdxContent(props) {\n' +
+      '  const _components = {\n' +
+      '    code: "code",\n' +
+      '    pre: "pre",\n' +
+      '    ...props.components\n' +
+      '  };\n' +
+      '  return <_components.pre hidden prop={prop}><_components.code className="language-js" /></_components.pre>;\n' +
+      '}\n' +
+      'export default function MDXContent(props = {}) {\n' +
+      '  const {wrapper: MDXLayout} = props.components || ({});\n' +
+      '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);\n' +
+      '}\n'
+  )
+})
+
+test('boolean properties false', async () => {
+  const { value } = await compile('```js prop={prop}\n```\n', {
+    jsx: true,
+    rehypePlugins: [
+      () => (ast: Root) => {
+        visitParents(ast, { type: 'element', tagName: 'pre' }, (element) => {
+          element.properties.hidden = false
+        })
+      },
+      rehypeMdxCodeProps
+    ]
+  })
+
+  assert.equal(
+    value,
+    '/*@jsxRuntime automatic*/\n' +
+      '/*@jsxImportSource react*/\n' +
+      'function _createMdxContent(props) {\n' +
+      '  const _components = {\n' +
+      '    code: "code",\n' +
+      '    pre: "pre",\n' +
+      '    ...props.components\n' +
+      '  };\n' +
+      '  return <_components.pre prop={prop}><_components.code className="language-js" /></_components.pre>;\n' +
+      '}\n' +
+      'export default function MDXContent(props = {}) {\n' +
+      '  const {wrapper: MDXLayout} = props.components || ({});\n' +
+      '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);\n' +
+      '}\n'
+  )
+})
+
+test('boolean properties empty', async () => {
+  const { value } = await compile('```js prop={prop}\n```\n', {
+    jsx: true,
+    rehypePlugins: [
+      () => (ast: Root) => {
+        visitParents(ast, { type: 'element', tagName: 'pre' }, (element) => {
+          element.properties.hidden = ''
+        })
+      },
+      rehypeMdxCodeProps
+    ]
+  })
+
+  assert.equal(
+    value,
+    '/*@jsxRuntime automatic*/\n' +
+      '/*@jsxImportSource react*/\n' +
+      'function _createMdxContent(props) {\n' +
+      '  const _components = {\n' +
+      '    code: "code",\n' +
+      '    pre: "pre",\n' +
+      '    ...props.components\n' +
+      '  };\n' +
+      '  return <_components.pre prop={prop}><_components.code className="language-js" /></_components.pre>;\n' +
+      '}\n' +
+      'export default function MDXContent(props = {}) {\n' +
+      '  const {wrapper: MDXLayout} = props.components || ({});\n' +
+      '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);\n' +
+      '}\n'
+  )
+})
+
+test('numeric properties', async () => {
+  const { value } = await compile('```js prop={prop}\n```\n', {
+    jsx: true,
+    rehypePlugins: [
+      () => (ast: Root) => {
+        visitParents(ast, { type: 'element', tagName: 'pre' }, (element) => {
+          element.properties.height = 42
+        })
+      },
+      rehypeMdxCodeProps
+    ]
+  })
+
+  assert.equal(
+    value,
+    '/*@jsxRuntime automatic*/\n' +
+      '/*@jsxImportSource react*/\n' +
+      'function _createMdxContent(props) {\n' +
+      '  const _components = {\n' +
+      '    code: "code",\n' +
+      '    pre: "pre",\n' +
+      '    ...props.components\n' +
+      '  };\n' +
+      '  return <_components.pre height="42" prop={prop}><_components.code className="language-js" /></_components.pre>;\n' +
+      '}\n' +
+      'export default function MDXContent(props = {}) {\n' +
+      '  const {wrapper: MDXLayout} = props.components || ({});\n' +
+      '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);\n' +
+      '}\n'
+  )
+})
+
+test('comma separated properties', async () => {
+  const { value } = await compile('```js prop={prop}\n```\n', {
+    jsx: true,
+    rehypePlugins: [
+      () => (ast: Root) => {
+        visitParents(ast, { type: 'element', tagName: 'pre' }, (element) => {
+          element.properties.accept = ['a', 'b']
+        })
+      },
+      rehypeMdxCodeProps
+    ]
+  })
+
+  assert.equal(
+    value,
+    '/*@jsxRuntime automatic*/\n' +
+      '/*@jsxImportSource react*/\n' +
+      'function _createMdxContent(props) {\n' +
+      '  const _components = {\n' +
+      '    code: "code",\n' +
+      '    pre: "pre",\n' +
+      '    ...props.components\n' +
+      '  };\n' +
+      '  return <_components.pre accept="a, b" prop={prop}><_components.code className="language-js" /></_components.pre>;\n' +
       '}\n' +
       'export default function MDXContent(props = {}) {\n' +
       '  const {wrapper: MDXLayout} = props.components || ({});\n' +

--- a/src/test.ts
+++ b/src/test.ts
@@ -331,6 +331,40 @@ test('numeric properties', async () => {
   )
 })
 
+test('style property', async () => {
+  const { value } = await compile('```js prop={prop}\n```\n', {
+    jsx: true,
+    rehypePlugins: [
+      () => (ast: Root) => {
+        visitParents(ast, { type: 'element', tagName: 'pre' }, (element) => {
+          element.properties.style = 'background-color:tomato;'
+        })
+      },
+      rehypeMdxCodeProps
+    ]
+  })
+
+  assert.equal(
+    value,
+    '/*@jsxRuntime automatic*/\n' +
+      '/*@jsxImportSource react*/\n' +
+      'function _createMdxContent(props) {\n' +
+      '  const _components = {\n' +
+      '    code: "code",\n' +
+      '    pre: "pre",\n' +
+      '    ...props.components\n' +
+      '  };\n' +
+      '  return <_components.pre style={{\n' +
+      '    "backgroundColor": "tomato"\n' +
+      '  }} prop={prop}><_components.code className="language-js" /></_components.pre>;\n' +
+      '}\n' +
+      'export default function MDXContent(props = {}) {\n' +
+      '  const {wrapper: MDXLayout} = props.components || ({});\n' +
+      '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);\n' +
+      '}\n'
+  )
+})
+
 test('comma separated properties', async () => {
   const { value } = await compile('```js prop={prop}\n```\n', {
     jsx: true,


### PR DESCRIPTION
This generates `mdxJsxAttribute` nodes instead of turning the entire hast tree into an ESTree embedded in a `mdxFlowExpression` node.

This means that hast nodes can still be processed after running the `rehype-mdx-code-props` transformer.